### PR TITLE
Allow imports of SVG's to point into node modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ const CloseSVG = () => <svg>{/* ... */}</svg>;
 const MyComponent = () => <CloseSvg />;
 ```
 
+You can also import SVGs from other NPM packages. Here I'm importing an SVG from a fictive `example` package:
+
+
+```jsx
+import React from 'react';
+import CloseSVG from 'example/assets/close.svg';
+
+const MyComponent = () => <CloseSvg />;
+```
+
 ## Installation
 
 ```


### PR DESCRIPTION
If the imported SVG can be read, we will try to `require.resolve` it instead.

I didn't add this functionality to the sanity check, as it would require a dev dependency to some package containing a SVG. But I have tested the functionality in combination with the project where I need the functionality. I'll add it to the sanity check if you want me to.