### PR TITLE
Use defaultProps instead of adding props to the svg

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,11 @@ const buildSvg = template(`
   var SVG_NAME = function SVG_NAME(props) { return SVG_CODE; };
 `);
 
+const buildSvgWithDefaults = template(`
+  var SVG_NAME = function SVG_NAME(props) { return SVG_CODE; };
+  SVG_NAME.defaultProps = SVG_DEFAULT_PROPS_CODE;
+`);
+
 let ignoreRegex;
 
 export default ({ types: t }) => ({
@@ -45,12 +50,40 @@ export default ({ types: t }) => ({
 
         const svgCode = traverse.removeProperties(parsedSvgAst.program.body[0].expression);
 
-        const svgReplacement = buildSvg({
+        const opts = {
           SVG_NAME: importIdentifier,
           SVG_CODE: svgCode,
-        });
+        };
 
-        path.replaceWith(svgReplacement);
+        // Move props off of element and into defaultProps
+        if (svgCode.openingElement.attributes.length > 1) {
+          const keepProps = [];
+          const defaultProps = [];
+
+          svgCode.openingElement.attributes.forEach((prop) => {
+            if (prop.type === 'JSXSpreadAttribute') {
+              keepProps.push(prop);
+            } else {
+              defaultProps.push(
+                t.objectProperty(
+                  t.identifier(prop.name.name),
+                  prop.value,
+                )
+              );
+            }
+          });
+
+          svgCode.openingElement.attributes = keepProps;
+          opts.SVG_DEFAULT_PROPS_CODE = t.objectExpression(defaultProps);
+        }
+
+        if (opts.SVG_DEFAULT_PROPS_CODE) {
+          const svgReplacement = buildSvgWithDefaults(opts);
+          path.replaceWithMultiple(svgReplacement);
+        } else {
+          const svgReplacement = buildSvg(opts);
+          path.replaceWith(svgReplacement);
+        }
       }
     },
   },


### PR DESCRIPTION
Currently, when transforming an SVG file that has attributes on the
top-level `<svg>` element, the transformed component ends up looking
something like this:

```js
_extends({
  xmlns: 'http://www.w3.org/2000/svg',
  viewBox: '0 0 1000 1000'
}, props),
```

this adds the overhead of _extends. I think it might be a better to
instead move these values into `defaultProps` on the generated
component.

Here's the diff of the result:

```diff
diff --git a/master.js b/default-props.js
index cb187ed..e62cca0 100644
--- a/master.js
+++ b/default-props.js
@@ -9,8 +9,6 @@ exports.MyClassIcon = undefined;
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
-var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
-
 exports.MyFunctionIcon = MyFunctionIcon;
 
 var _react = require('react');
@@ -29,12 +27,7 @@ var MySvg = function () {
   function MySvg(props) {
     return _react2['default'].createElement(
       'svg',
-      _extends({
-        dataName: 'Livello 1',
-        id: 'Livello_1',
-        viewBox: '0 0 151.57 151.57',
-        xmlns: 'http://www.w3.org/2000/svg'
-      }, props),
+      props,
       _react2['default'].createElement('title', null),
       _react2['default'].createElement('circle', {
         cx: '1038.5',
@@ -78,6 +71,12 @@ var MySvg = function () {
   return MySvg;
 }();
 
+MySvg.defaultProps = {
+  dataName: 'Livello 1',
+  id: 'Livello_1',
+  viewBox: '0 0 151.57 151.57',
+  xmlns: 'http://www.w3.org/2000/svg'
+};
 function MyFunctionIcon() {
   return _react2['default'].createElement(MySvg, null);
 }
```

Closes #7