### PR TITLE
Fix typo in svgo options example in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ npm install --save-dev babel-plugin-inline-react-svg
               "removeAttrs": { "attrs": "(data-name)" }
             },
             {
-              "cleanupIds": true
+              "cleanupIDs": true
             }
           ]
 


### PR DESCRIPTION
This is really minor, but I stumbled upon it when I wanted to *disable* `cleanupIDs` and I had just copy-pasted your example.

Reference: [SVGO cleanupIDs plugin](https://github.com/svg/svgo/blob/master/plugins/cleanupIDs.js)

Thanks for a great tool!