### PR TITLE
Support passing an alias object to fix issues with babel module resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,31 @@ npm install --save-dev babel-plugin-inline-react-svg
     ]
   ]
 }
-
 ```
+- *`alias`* - An object with alias for module resolution
+- *`root`* - A relative path string (Starting from CWD), it only works in conjunction with alias.
+Example:
+
+```json
+{
+  "plugins": [
+    [
+      "inline-react-svg",
+      {
+        "alias": {
+          "plugins": [
+            "root": "./",
+            "alias": {
+            "svgs": "svgs"
+            }
+          ]
+        }
+      }
+    ]
+  ]
+}
+```
+**Note:** If root is not specified it will always start resolving from the project root
 
 ### Via CLI
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-inline-react-svg",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "A babel plugin that optimizes and inlines SVGs for your react components.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Given a .babelrc like this

```
{
  "presets": ["next/babel"],
  "plugins": [
    ["inline-react-svg", {
      "root": "./",
      "alias": {
        "svgs": "svgs"
       }
    }],
   ["module-resolver", {
     "root": ["./"],
     "alias": {
       "svgs": "svgs"
      }
  }]
 ]
}
```
Supports basically the same syntax as module-resolver but root has to be a string not an array

Closes #14 

Let me know what do you think