### PR TITLE
Implement case-sensitivity check

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ npm install --save-dev babel-plugin-inline-react-svg
 #### Options
 
 - *`ignorePattern`* - A pattern that imports will be tested against to selectively ignore imports.
+- *`caseSensitive`* - A boolean value that if true will require file paths to match with case-sensitivity. Useful to ensure consistent behavior if working on both a case-sensitive operating system like Linux and a case-insensitive one like OS X or Windows.
 - *`svgo`* - svgo options (`false` to disable). Example:
 ```json
 {

--- a/src/fileExistsWithCaseSync.js
+++ b/src/fileExistsWithCaseSync.js
@@ -1,0 +1,10 @@
+var fs = require('fs');
+var path = require('path');
+
+// Based on https://stackoverflow.com/questions/27367261/check-if-file-exists-case-sensitive
+export default function fileExistsWithCaseSync(filepath) {
+    var dir = path.dirname(filepath);
+    if (dir === '/' || dir === '.') return true;
+    var filenames = fs.readdirSync(dir);
+    return filenames.indexOf(path.basename(filepath)) !== -1;
+}

--- a/test/fixtures/test-case-sensitive.jsx
+++ b/test/fixtures/test-case-sensitive.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import MySvg from './Close.svg';
+
+export function MyFunctionIcon() {
+  return <MySvg />;
+}
+
+export class MyClassIcon extends React.Component {
+  render() {
+    return <MySvg />;
+  }
+}

--- a/test/sanity.js
+++ b/test/sanity.js
@@ -9,3 +9,19 @@ transformFile('test/fixtures/test.jsx', {
   if (err) throw err;
   console.log(result.code);
 });
+
+transformFile('test/fixtures/test-case-sensitive.jsx', {
+  presets: ['airbnb'],
+  plugins: [
+    ['../../src/index',
+    {
+        "caseSensitive": true
+    }]
+  ],
+}, (err, result) => {
+  if (err && err.message.indexOf('match case') !== -1) {
+    console.log("Test passed: Expected case sensitive error was thrown");
+  } else {
+    throw new Error("Test failed: Expected case sensitive error wasn't thrown");
+  }
+});


### PR DESCRIPTION
Adds a new optional flag that makes the plugin check for case-sensitivity when loading files.

If you have team with a Linux build server and OS X and Windows development machines, this will ensure consistent behavior.