### PR TITLE
[Fix] Only ensure a React import when there’s an svg import in the file.

### DIFF
--- a/test/fixtures/test-no-svg-or-react.js
+++ b/test/fixtures/test-no-svg-or-react.js
@@ -1,0 +1,5 @@
+import './path/to.jpg';
+import './code.js';
+
+export default class Foo {
+}

--- a/test/sanity.js
+++ b/test/sanity.js
@@ -49,3 +49,17 @@ transformFile('test/fixtures/test-case-sensitive.jsx', {
     throw new Error("Test failed: Expected case sensitive error wasn't thrown");
   }
 });
+
+transformFile('test/fixtures/test-no-svg-or-react.js', {
+  babelrc: false,
+  presets: [],
+  plugins: [
+    '../../src/index',
+  ],
+}, (err, result) => {
+  if (err) throw err;
+  console.log('test/fixtures/test-no-svg-or-react.js', result.code);
+  if (/React/.test(result.code)) {
+    throw new Error('Test failed: React import was present');
+  }
+});


### PR DESCRIPTION
Fixes an issue caused by #29.

This only ensures that there's a React import when there's an svg in the file; instead of just unconditionally.