### PR TITLE
Updating to svgo ^1.0.3 and synchronizing promise

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "babel-traverse": "^6.15.0",
     "babylon": "^6.10.0",
     "lodash.isplainobject": "^4.0.6",
+    "promise-synchronizer": "^1.0.6",
     "resolve-from": "^2.0.0",
-    "svgo": "^0.7.0"
+    "svgo": "^1.0.3"
   }
 }

--- a/src/optimize.js
+++ b/src/optimize.js
@@ -3,6 +3,7 @@
 // for the babylon JSX parser to work
 import Svgo from 'svgo';
 import isPlainObject from 'lodash.isplainobject';
+import sync from 'promise-synchronizer';
 
 const essentialPlugins = ['removeDoctype', 'removeComments'];
 
@@ -54,15 +55,21 @@ export default function optimize(content, opts = {}) {
   validateAndFix(opts);
   const svgo = new Svgo(opts);
 
-  // Svgo isn't _really_ async, so let's do it this way:
+  // Svgo isn't _really_ async, it however is async enough to require some handling:
   let returnValue;
-  svgo.optimize(content, (response) => {
-    if (response.error) {
-      returnValue = response.error;
-    } else {
-      returnValue = response.data;
-    }
-  });
+  try {
+    sync(svgo.optimize(content)
+      .then((response) => {
+        if (response.error) {
+          throw response.error;
+        } else {
+          returnValue = response.data;
+        }
+      })
+    );
+  } catch (error) {
+    returnValue = error;
+  }
 
   return returnValue;
 }


### PR DESCRIPTION
This is a fully working update to `svgo@^1.0.3`, closing #34 on the way.